### PR TITLE
Added wrappers for SCIP changes to Benders initialisation

### DIFF
--- a/src/pyscipopt/__init__.py
+++ b/src/pyscipopt/__init__.py
@@ -39,4 +39,5 @@ from pyscipopt.scip      import PY_SCIP_EVENTTYPE    as SCIP_EVENTTYPE
 from pyscipopt.scip      import PY_SCIP_LPSOLSTAT    as SCIP_LPSOLSTAT
 from pyscipopt.scip      import PY_SCIP_BRANCHDIR    as SCIP_BRANCHDIR
 from pyscipopt.scip      import PY_SCIP_BENDERSENFOTYPE as SCIP_BENDERSENFOTYPE
+from pyscipopt.scip      import PY_SCIP_BENDERSSUBTYPE as SCIP_BENDERSSUBTYPE
 from pyscipopt.scip      import PY_SCIP_ROWORIGINTYPE as SCIP_ROWORIGINTYPE

--- a/src/pyscipopt/benders.pxi
+++ b/src/pyscipopt/benders.pxi
@@ -123,11 +123,12 @@ cdef SCIP_RETCODE PyBendersExitsol (SCIP* scip, SCIP_BENDERS* benders) with gil:
     PyBenders.bendersexitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBendersCreatesub (SCIP* scip, SCIP_BENDERS* benders, int probnumber) with gil:
+cdef SCIP_RETCODE PyBendersCreatesub (SCIP* scip, SCIP_BENDERS* benders, int probnumber, SCIP_Bool* initialise) with gil:
     cdef SCIP_BENDERSDATA* bendersdata
     bendersdata = SCIPbendersGetData(benders)
     PyBenders = <Benders>bendersdata
-    PyBenders.benderscreatesub(probnumber)
+    result_dict = PyBenders.benderscreatesub(probnumber)
+    initialise[0] = result_dict.get("initialise", False)
     return SCIP_OKAY
 
 cdef SCIP_RETCODE PyBendersPresubsolve (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, SCIP_BENDERSENFOTYPE type, SCIP_Bool checkint, SCIP_Bool* infeasible, SCIP_Bool* auxviol, SCIP_Bool* skipsolve,  SCIP_RESULT* result) with gil:

--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -1149,6 +1149,7 @@ cdef extern from "scip/scip.h":
     SCIP_RETCODE SCIPcheckBendersSubproblemOptimality(SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber, SCIP_Bool* optimal)
     SCIP_RETCODE SCIPincludeBendersDefaultCuts(SCIP* scip, SCIP_BENDERS* benders)
     void SCIPbendersSetSubproblemIsConvex(SCIP_BENDERS* benders, int probnumber, SCIP_Bool isconvex)
+    void SCIPbendersSetSubproblemUseLPsolve(SCIP_BENDERS* benders, int probnumber, SCIP_Bool useLPsolve)
 
     # Benders' decomposition cuts plugin
     SCIP_RETCODE SCIPincludeBenderscut(SCIP* scip,

--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -1149,7 +1149,6 @@ cdef extern from "scip/scip.h":
     SCIP_RETCODE SCIPcheckBendersSubproblemOptimality(SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber, SCIP_Bool* optimal)
     SCIP_RETCODE SCIPincludeBendersDefaultCuts(SCIP* scip, SCIP_BENDERS* benders)
     void SCIPbendersSetSubproblemIsConvex(SCIP_BENDERS* benders, int probnumber, SCIP_Bool isconvex)
-    void SCIPbendersSetSubproblemUseLPsolve(SCIP_BENDERS* benders, int probnumber, SCIP_Bool useLPsolve)
 
     # Benders' decomposition cuts plugin
     SCIP_RETCODE SCIPincludeBenderscut(SCIP* scip,

--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -1125,6 +1125,8 @@ cdef extern from "scip/scip.h":
                                    SCIP_RETCODE (*bendersfreesub) (SCIP* scip, SCIP_BENDERS* benders, int probnumber),
                                    SCIP_BENDERSDATA* bendersdata)
     SCIP_BENDERS* SCIPfindBenders(SCIP* scip, const char* name)
+    SCIP_RETCODE SCIPinitialiseBendersSubproblem(SCIP* scip, SCIP_BENDERS* benders, int probnumber, SCIP_Bool* success)
+    SCIP_RETCODE SCIPinitialiseBendersLPSubproblem(SCIP* scip, SCIP_BENDERS* benders, int probnumber)
     SCIP_RETCODE SCIPactivateBenders(SCIP* scip, SCIP_BENDERS* benders, int nsubproblems)
     SCIP_BENDERSDATA* SCIPbendersGetData(SCIP_BENDERS* benders)
     SCIP_RETCODE SCIPcreateBendersDefault(SCIP* scip, SCIP** subproblems, int nsubproblems)

--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -1117,7 +1117,7 @@ cdef extern from "scip/scip.h":
                                    SCIP_RETCODE (*bendersinitsol) (SCIP* scip, SCIP_BENDERS* benders),
                                    SCIP_RETCODE (*bendersexitsol) (SCIP* scip, SCIP_BENDERS* benders),
                                    SCIP_RETCODE (*bendersgetvar) (SCIP* scip, SCIP_BENDERS* benders, SCIP_VAR* var, SCIP_VAR** mappedvar, int probnumber),
-                                   SCIP_RETCODE (*benderscreatesub) (SCIP* scip, SCIP_BENDERS* benders, int probnumber),
+                                   SCIP_RETCODE (*benderscreatesub) (SCIP* scip, SCIP_BENDERS* benders, int probnumber, SCIP_Bool* initialise),
                                    SCIP_RETCODE (*benderspresubsolve) (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, SCIP_BENDERSENFOTYPE type, SCIP_Bool checkint, SCIP_Bool* infeasible, SCIP_Bool* auxviol, SCIP_Bool* skipsolve,  SCIP_RESULT* result),
                                    SCIP_RETCODE (*benderssolvesubconvex) (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber, SCIP_Bool onlyconvex, SCIP_Real* objective, SCIP_RESULT* result),
                                    SCIP_RETCODE (*benderssolvesub) (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber, SCIP_Real* objective, SCIP_RESULT* result),

--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -247,6 +247,13 @@ cdef extern from "scip/scip.h":
         SCIP_BENDERSENFOTYPE_PSEUDO  = 3
         SCIP_BENDERSENFOTYPE_CHECK   = 4
 
+    ctypedef enum SCIP_BENDERSSUBTYPE:
+        SCIP_BENDERSSUBTYPE_CONVEXCONT      = 0
+        SCIP_BENDERSSUBTYPE_CONVEXDIS       = 1
+        SCIP_BENDERSSUBTYPE_NONCONVEXCONT   = 2
+        SCIP_BENDERSSUBTYPE_NONCONVEXDIS    = 3
+        SCIP_BENDERSSUBTYPE_UNKNOWN         = 4
+
     ctypedef enum SCIP_LPSOLSTAT:
         SCIP_LPSOLSTAT_NOTSOLVED    = 0
         SCIP_LPSOLSTAT_OPTIMAL      = 1
@@ -1150,6 +1157,8 @@ cdef extern from "scip/scip.h":
     SCIP_VAR* SCIPbendersGetAuxiliaryVar(SCIP_BENDERS* benders, int probnumber)
     SCIP_RETCODE SCIPcheckBendersSubproblemOptimality(SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber, SCIP_Bool* optimal)
     SCIP_RETCODE SCIPincludeBendersDefaultCuts(SCIP* scip, SCIP_BENDERS* benders)
+    void SCIPbendersSetSubproblemType(SCIP_BENDERS* benders, int probnumber, SCIP_BENDERSSUBTYPE subprobtype)
+    SCIP_BENDERSSUBTYPE SCIPbendersGetSubproblemType(SCIP_BENDERS* benders, int probnumber)
     void SCIPbendersSetSubproblemIsConvex(SCIP_BENDERS* benders, int probnumber, SCIP_Bool isconvex)
 
     # Benders' decomposition cuts plugin

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -3226,6 +3226,9 @@ cdef class Model:
         """
         SCIPbendersSetSubproblemIsConvex(benders._benders, probnumber, isconvex)
 
+    def setBendersSubproblemUseLPsolve(self, Benders benders, probnumber, useLPsolve = True):
+        SCIPbendersSetSubproblemUseLPsolve(benders._benders, probnumber, useLPsolve)
+
     def setupBendersSubproblem(self, probnumber, Benders benders = None, Solution solution = None, checktype = PY_SCIP_BENDERSENFOTYPE.LP):
         """ sets up the Benders' subproblem given the master problem solution
 

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -3226,9 +3226,6 @@ cdef class Model:
         """
         SCIPbendersSetSubproblemIsConvex(benders._benders, probnumber, isconvex)
 
-    def setBendersSubproblemUseLPsolve(self, Benders benders, probnumber, useLPsolve = True):
-        SCIPbendersSetSubproblemUseLPsolve(benders._benders, probnumber, useLPsolve)
-
     def setupBendersSubproblem(self, probnumber, Benders benders = None, Solution solution = None, checktype = PY_SCIP_BENDERSENFOTYPE.LP):
         """ sets up the Benders' subproblem given the master problem solution
 

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -3196,6 +3196,20 @@ cdef class Model:
         for d in lowerbounds.keys():
             SCIPbendersUpdateSubproblemLowerbound(_benders, d, lowerbounds[d])
 
+    def initialiseSubproblem(self, Benders benders, int probnumber):
+        """
+        """
+        cdef SCIP_Bool success
+
+        PY_SCIP_CALL( SCIPinitialiseBendersSubproblem(self._scip, benders._benders, probnumber, &success) )
+
+        return success
+
+    def initialiseLPSubproblem(self, Benders benders, int probnumber):
+        """
+        """        
+        PY_SCIP_CALL( SCIPinitialiseBendersLPSubproblem(self._scip, benders._benders, probnumber) )
+
     def activateBenders(self, Benders benders, int nsubproblems):
         """Activates the Benders' decomposition plugin with the input name
 

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -3197,7 +3197,14 @@ cdef class Model:
             SCIPbendersUpdateSubproblemLowerbound(_benders, d, lowerbounds[d])
 
     def initialiseSubproblem(self, Benders benders, int probnumber):
-        """
+        """Initialises a MIP subproblem by putting the problem into SCIP_STAGE_SOLVING.
+
+        Keyword arguments:
+        benders -- the Benders' decomposition to which the subproblem belongs to
+        probnumber -- the number of the subproblem to be initialised
+
+        Returns:
+        success -- was the initialisation successsful
         """
         cdef SCIP_Bool success
 
@@ -3206,7 +3213,11 @@ cdef class Model:
         return success
 
     def initialiseLPSubproblem(self, Benders benders, int probnumber):
-        """
+        """Initialises an LP subproblem by putting the problem into probing mode.
+
+        Keyword arguments:
+        benders -- the Benders' decomposition to which the subproblem belongs to
+        probnumber -- the number of the subproblem to be initialised
         """        
         PY_SCIP_CALL( SCIPinitialiseBendersLPSubproblem(self._scip, benders._benders, probnumber) )
 

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -219,6 +219,13 @@ cdef class PY_SCIP_BENDERSENFOTYPE:
     PSEUDO = SCIP_BENDERSENFOTYPE_PSEUDO
     CHECK  = SCIP_BENDERSENFOTYPE_CHECK
 
+cdef class PY_SCIP_BENDERSSUBTYPE:
+    CONVEXCONT      = SCIP_BENDERSSUBTYPE_CONVEXCONT
+    CONVEXDIS       = SCIP_BENDERSSUBTYPE_CONVEXDIS
+    NONCONVEXCONT   = SCIP_BENDERSSUBTYPE_NONCONVEXCONT
+    NONCONVEXDIS    = SCIP_BENDERSSUBTYPE_NONCONVEXDIS
+    UNKNOWN         = SCIP_BENDERSSUBTYPE_UNKNOWN
+
 cdef class PY_SCIP_ROWORIGINTYPE:
     UNSPEC = SCIP_ROWORIGINTYPE_UNSPEC
     CONS   = SCIP_ROWORIGINTYPE_CONS
@@ -3240,6 +3247,35 @@ cdef class Model:
         isconvex -- can be used to specify whether the subproblem is convex
         """
         PY_SCIP_CALL(SCIPaddBendersSubproblem(self._scip, benders._benders, (<Model>subproblem)._scip))
+
+    def setBendersSubproblemType(self, Benders benders, int probnumber, subprobtype):
+        """Sets the subproblem type
+        The subproblem types are:
+            - Convex constraints with continuous variables
+            - Convex constraints with discrete variables
+            - Non-convex constraints with continuous variables
+            - Non-convex constraints with discrete variables
+
+        Keyword arguments:
+        benders -- the Benders' decomposition which contains the subproblem
+        probnumber -- the problem number of the subproblem that the type is to be set for
+        subprobtype -- the type of the subproblem
+        """
+        SCIPbendersSetSubproblemType(benders._benders, probnumber, subprobtype)
+
+    def getBendersSubproblemType(self, Benders benders, int probnumber):
+        """Gets the subproblem type
+        The subproblem types are:
+            - Convex constraints with continuous variables
+            - Convex constraints with discrete variables
+            - Non-convex constraints with continuous variables
+            - Non-convex constraints with discrete variables
+
+        Keyword arguments:
+        benders -- the Benders' decomposition which contains the subproblem
+        probnumber -- the problem number of the subproblem to find the type of
+        """
+        return SCIPbendersGetSubproblemType(benders._benders, probnumber)
 
     def setBendersSubproblemIsConvex(self, Benders benders, probnumber, isconvex = True):
         """sets a flag indicating whether the subproblem is convex


### PR DESCRIPTION
**Wrappers for SCIP changes**
Wrappers are added for the new SCIP functionality I have added via [this pull request](https://github.com/ORowell/scip/pull/2#issue-709161277). This includes two new public functions initialiseSubproblem and initialiseLPSubproblem and managing of the returnable initialise parameter for benderscreatesub

**New enum wrapper**
Added SCIP_BENDERSSUBTYPE enums to allow interfacing with the SCIP equivalents
