### PR TITLE
Wrappers for new callbacks

### DIFF
--- a/src/pyscipopt/__init__.py
+++ b/src/pyscipopt/__init__.py
@@ -39,4 +39,5 @@ from pyscipopt.scip      import PY_SCIP_EVENTTYPE    as SCIP_EVENTTYPE
 from pyscipopt.scip      import PY_SCIP_LPSOLSTAT    as SCIP_LPSOLSTAT
 from pyscipopt.scip      import PY_SCIP_BRANCHDIR    as SCIP_BRANCHDIR
 from pyscipopt.scip      import PY_SCIP_BENDERSENFOTYPE as SCIP_BENDERSENFOTYPE
+from pyscipopt.scip      import PY_SCIP_BENDERSSUBSTATUS as SCIP_BENDERSSUBSTATUS
 from pyscipopt.scip      import PY_SCIP_ROWORIGINTYPE as SCIP_ROWORIGINTYPE

--- a/src/pyscipopt/benders.pxi
+++ b/src/pyscipopt/benders.pxi
@@ -51,10 +51,15 @@ cdef class Benders:
         return {}
 
     def bendersprecut(self, solution, result, enfotype, subproblemsolved, subproblemstatus, infeasible, optimal):
+        '''sets the pre cut generation callback of Benders decomposition'''
         pass
 
     def benderspostsolve(self, solution, enfotype, mergecandidates, npriomergecands, checkint, infeasible):
         '''sets post-solve callback of Benders decomposition '''
+        return {}
+
+    def bendersenforcesol(self, solution, type, checkint):
+        '''sets the callback called before enforcing the solution to a subproblem'''
         return {}
 
     def bendersfreesub(self, probnumber):
@@ -213,6 +218,21 @@ cdef SCIP_RETCODE PyBendersPostsolve (SCIP* scip, SCIP_BENDERS* benders, SCIP_SO
         mergecandidates.append(mergecands[i])
     result_dict = PyBenders.benderspostsolve(solution, enfotype, mergecandidates, npriomergecands, checkint, infeasible)
     merged[0] = result_dict.get("merged", False)
+    return SCIP_OKAY
+
+cdef SCIP_RETCODE PyBendersEnforceSol(SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol,
+        SCIP_BENDERSENFOTYPE type, SCIP_Bool checkint, SCIP_Bool* skipenforce) with gil:
+    cdef SCIP_BENDERSDATA* bendersdata
+    bendersdata = SCIPbendersGetData(benders)
+    PyBenders = <Benders>bendersdata
+    if sol == NULL:
+        solution = None
+    else:
+        solution = Solution.create(scip, sol)
+    enfotype = type
+
+    result_dict = PyBenders.bendersenforcesol(solution, type, checkint)
+    skipenforce[0] = result_dict.get("skipenforce", False)
     return SCIP_OKAY
 
 cdef SCIP_RETCODE PyBendersFreesub (SCIP* scip, SCIP_BENDERS* benders, int probnumber) with gil:

--- a/src/pyscipopt/benders.pxi
+++ b/src/pyscipopt/benders.pxi
@@ -50,6 +50,9 @@ cdef class Benders:
         '''sets solve callback of Benders decomposition '''
         return {}
 
+    def bendersprecut(self, solution, result, enfotype, subproblemsolved, subproblemstatus, infeasible, optimal):
+        pass
+
     def benderspostsolve(self, solution, enfotype, mergecandidates, npriomergecands, checkint, infeasible):
         '''sets post-solve callback of Benders decomposition '''
         return {}
@@ -170,6 +173,28 @@ cdef SCIP_RETCODE PyBendersSolvesub (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL
     result_dict = PyBenders.benderssolvesub(solution, probnumber)
     objective[0] = result_dict.get("objective", 1e+20)
     result[0] = result_dict.get("result", <SCIP_RESULT>result[0])
+    return SCIP_OKAY
+
+cdef SCIP_RETCODE PyBendersPreCut (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, SCIP_RESULT result, SCIP_BENDERSENFOTYPE type,
+                                   SCIP_Bool* subprobsolved, SCIP_BENDERSSUBSTATUS* substatus, int nsubproblems, SCIP_Bool infeasible,
+                                   SCIP_Bool optimal) with gil:
+    cdef SCIP_BENDERSDATA* bendersdata
+    bendersdata = SCIPbendersGetData(benders)
+    PyBenders = <Benders>bendersdata
+
+    if sol == NULL:
+        solution = None
+    else:
+        solution = Solution.create(scip, sol)
+    enfotype = type
+
+    subproblemsolved = []
+    subproblemstatus = []
+    for i in range(nsubproblems):
+        subproblemsolved.append(bool(subprobsolved[i]))
+        subproblemstatus.append(substatus[i])
+
+    PyBenders.bendersprecut(solution, result, enfotype, subproblemsolved, subproblemstatus, infeasible, optimal)
     return SCIP_OKAY
 
 cdef SCIP_RETCODE PyBendersPostsolve (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol,

--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -247,6 +247,12 @@ cdef extern from "scip/scip.h":
         SCIP_BENDERSENFOTYPE_PSEUDO  = 3
         SCIP_BENDERSENFOTYPE_CHECK   = 4
 
+    ctypedef enum SCIP_BENDERSSUBSTATUS:
+        SCIP_BENDERSSUBSTATUS_UNKNOWN    = 0
+        SCIP_BENDERSSUBSTATUS_OPTIMAL    = 1
+        SCIP_BENDERSSUBSTATUS_AUXVIOL    = 2
+        SCIP_BENDERSSUBSTATUS_INFEAS     = 3 
+
     ctypedef enum SCIP_LPSOLSTAT:
         SCIP_LPSOLSTAT_NOTSOLVED    = 0
         SCIP_LPSOLSTAT_OPTIMAL      = 1
@@ -1121,6 +1127,7 @@ cdef extern from "scip/scip.h":
                                    SCIP_RETCODE (*benderspresubsolve) (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, SCIP_BENDERSENFOTYPE type, SCIP_Bool checkint, SCIP_Bool* infeasible, SCIP_Bool* auxviol, SCIP_Bool* skipsolve,  SCIP_RESULT* result),
                                    SCIP_RETCODE (*benderssolvesubconvex) (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber, SCIP_Bool onlyconvex, SCIP_Real* objective, SCIP_RESULT* result),
                                    SCIP_RETCODE (*benderssolvesub) (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber, SCIP_Real* objective, SCIP_RESULT* result),
+                                   SCIP_RETCODE (*bendersprecut) (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, SCIP_RESULT result, SCIP_BENDERSENFOTYPE type, SCIP_Bool* subprobsolved, SCIP_BENDERSSUBSTATUS* substatus, int nsubproblems, SCIP_Bool infeasible, SCIP_Bool optimal),
                                    SCIP_RETCODE (*benderspostsolve) (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, SCIP_BENDERSENFOTYPE type, int* mergecands, int npriomergecands, int nmergecands, SCIP_Bool checkint, SCIP_Bool infeasible, SCIP_Bool* merged),
                                    SCIP_RETCODE (*bendersfreesub) (SCIP* scip, SCIP_BENDERS* benders, int probnumber),
                                    SCIP_BENDERSDATA* bendersdata)

--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -1129,6 +1129,7 @@ cdef extern from "scip/scip.h":
                                    SCIP_RETCODE (*benderssolvesub) (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber, SCIP_Real* objective, SCIP_RESULT* result),
                                    SCIP_RETCODE (*bendersprecut) (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, SCIP_RESULT result, SCIP_BENDERSENFOTYPE type, SCIP_Bool* subprobsolved, SCIP_BENDERSSUBSTATUS* substatus, int nsubproblems, SCIP_Bool infeasible, SCIP_Bool optimal),
                                    SCIP_RETCODE (*benderspostsolve) (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, SCIP_BENDERSENFOTYPE type, int* mergecands, int npriomergecands, int nmergecands, SCIP_Bool checkint, SCIP_Bool infeasible, SCIP_Bool* merged),
+                                   SCIP_RETCODE (*bendersenforcesol) (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, SCIP_BENDERSENFOTYPE type, SCIP_Bool checkint, SCIP_Bool* skipenforce),
                                    SCIP_RETCODE (*bendersfreesub) (SCIP* scip, SCIP_BENDERS* benders, int probnumber),
                                    SCIP_BENDERSDATA* bendersdata)
     SCIP_BENDERS* SCIPfindBenders(SCIP* scip, const char* name)

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -3684,8 +3684,8 @@ cdef class Model:
                                             PyBendersCopy, PyBendersFree, PyBendersInit, PyBendersExit, PyBendersInitpre,
                                             PyBendersExitpre, PyBendersInitsol, PyBendersExitsol, PyBendersGetvar,
                                             PyBendersCreatesub, PyBendersPresubsolve, PyBendersSolvesubconvex,
-                                            PyBendersSolvesub, PyBendersPreCut, PyBendersPostsolve, PyBendersFreesub,
-                                            <SCIP_BENDERSDATA*>benders))
+                                            PyBendersSolvesub, PyBendersPreCut, PyBendersPostsolve, PyBendersEnforceSol,
+                                            PyBendersFreesub, <SCIP_BENDERSDATA*>benders))
         cdef SCIP_BENDERS* scip_benders
         scip_benders = SCIPfindBenders(self._scip, n)
         benders.model = <Model>weakref.proxy(self)

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -219,6 +219,12 @@ cdef class PY_SCIP_BENDERSENFOTYPE:
     PSEUDO = SCIP_BENDERSENFOTYPE_PSEUDO
     CHECK  = SCIP_BENDERSENFOTYPE_CHECK
 
+cdef class PY_SCIP_BENDERSSUBSTATUS:
+    UNKNOWN     = SCIP_BENDERSSUBSTATUS_UNKNOWN
+    OPTIMAL     = SCIP_BENDERSSUBSTATUS_OPTIMAL
+    AUXVIOL     = SCIP_BENDERSSUBSTATUS_AUXVIOL
+    INFEAS      = SCIP_BENDERSSUBSTATUS_INFEAS
+
 cdef class PY_SCIP_ROWORIGINTYPE:
     UNSPEC = SCIP_ROWORIGINTYPE_UNSPEC
     CONS   = SCIP_ROWORIGINTYPE_CONS
@@ -3678,7 +3684,7 @@ cdef class Model:
                                             PyBendersCopy, PyBendersFree, PyBendersInit, PyBendersExit, PyBendersInitpre,
                                             PyBendersExitpre, PyBendersInitsol, PyBendersExitsol, PyBendersGetvar,
                                             PyBendersCreatesub, PyBendersPresubsolve, PyBendersSolvesubconvex,
-                                            PyBendersSolvesub, PyBendersPostsolve, PyBendersFreesub,
+                                            PyBendersSolvesub, PyBendersPreCut, PyBendersPostsolve, PyBendersFreesub,
                                             <SCIP_BENDERSDATA*>benders))
         cdef SCIP_BENDERS* scip_benders
         scip_benders = SCIPfindBenders(self._scip, n)


### PR DESCRIPTION
**Wrappers for SCIP changes**
Wrappers are added for the new SCIP functionality I have added via [this pull request](https://github.com/ORowell/scip/pull/3#issue-709163796). This includes wrappers for two new methods bendersprecut and bendersenforcesol.

**New enum wrappers**
Added SCIP_BENDERSSUBSTATUS enums to allow interfacing with the SCIP equivalent